### PR TITLE
Document the mmap(...) failed runtime error

### DIFF
--- a/doc/e9patch.1
+++ b/doc/e9patch.1
@@ -194,6 +194,19 @@ Default: \fBfalse\fR (disabled)
 .TP
 \fB\-\-version\fR
 Print the version and exit.
+.SH "TROUBLESHOOTING"
+The instrumented binary may sometimes fail to run properly.
+See below for solutions to common problems.
+.TP
+\fBe9patch loader error: mmap(...) failed (errno=12)\fR
+This occurs when the instrumented binary uses too many mappings.
+This can usually be fixed by lowering the compression level,
+see the \fB--compression\fR option for E9Tool (see \fBman e9tool\fR).
+.TP
+\fBTrace/breakpoint trap\fR
+If using Control Flow Recovery (CFR) mode, the input binary may be
+incompatible.
+Disable CFR to resolve the issue.
 .SH "SEE ALSO"
 \fIe9tool\fR(1), \fIe9compile\fR(1), \fIe9afl\fR(1), \fIredfat\fR(1)
 .SH AUTHOR

--- a/src/e9patch/e9loader_elf.cpp
+++ b/src/e9patch/e9loader_elf.cpp
@@ -147,19 +147,22 @@ static NO_INLINE void e9load_maps(const e9_map_s *maps, uint32_t num_maps,
         int prot = (maps[i].r? PROT_READ: 0x0) |
                    (maps[i].w? PROT_WRITE: 0x0) |
                    (maps[i].x? PROT_EXEC: 0x0);
+        int flags = MAP_FIXED | MAP_PRIVATE;
 #if 0
         e9debug("mmap(addr=%p,size=%U,offset=+%U,prot=%c%c%c)",
             addr, len, offset,
             (maps[i].r? 'r': '-'), (maps[i].w? 'w': '-'),
             (maps[i].x? 'x': '-'));
 #endif
-        intptr_t result = mmap((void *)addr, len, prot, MAP_FIXED | MAP_PRIVATE,
-            fd, offset);
+        intptr_t result = mmap((void *)addr, len, prot, flags, fd, offset);
         if (result < 0)
             e9panic("mmap(addr=%p,size=%U,offset=+%U,prot=%c%c%c) failed "
-                "(errno=%u)", addr, len, offset,
+                "(errno=%u)%s", addr, len, offset,
                 (maps[i].r? 'r': '-'), (maps[i].w? 'w': '-'),
-                (maps[i].x? 'x': '-'), -(int)result);
+                (maps[i].x? 'x': '-'), -(int)result,
+                (-(int)result == ENOMEM?
+                    "\nhint: see the e9patch manpage for more information.":
+                    ""));
     }
 }
 


### PR DESCRIPTION
Fixes a usability issue.

Some users miss the warning message.  So now the
runtime loader will tell the user to check the
manpage & the manpage now documents the fix.